### PR TITLE
Adds async support on listeners

### DIFF
--- a/eolic/base.py
+++ b/eolic/base.py
@@ -1,13 +1,15 @@
 """Module for eolic base class."""
 
 import functools
-from typing import Any, Callable, List
+from typing import Any, Callable, List, TypeVar, cast
 
 from eolic.integrations.base import Integration
 
 from .listener import EventListenerHandler
 from .meta.singleton import Singleton
 from .remote import EventRemoteTargetHandler
+
+T = TypeVar("T", bound=Callable[..., Any])
 
 
 class Eolic(metaclass=Singleton):
@@ -67,7 +69,7 @@ class Eolic(metaclass=Singleton):
             Callable: The decorator function.
         """
 
-        def decorator(func):
+        def decorator(func: T) -> T:
             self.listener_handler.register(event, func)
 
             @functools.wraps(func)
@@ -76,7 +78,7 @@ class Eolic(metaclass=Singleton):
                 # it's not showing up in the coverage report
                 return func(*args, **kwargs)  # pragma: no cover
 
-            return wrapper
+            return cast(T, wrapper)
 
         return decorator
 

--- a/eolic/helpers/__init__.py
+++ b/eolic/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Module that holds all helpers for Eolic."""

--- a/eolic/helpers/coroutines.py
+++ b/eolic/helpers/coroutines.py
@@ -14,8 +14,11 @@ def run_coroutine(coroutine: Callable[..., Any], *args, **kwargs) -> Any:
     Returns:
         Any: The result of the coroutine.
     """
-    loop = asyncio.get_event_loop()
-    if loop.is_running():
-        return asyncio.ensure_future(coroutine(*args, **kwargs))
-    else:
-        return loop.run_until_complete(coroutine(*args, **kwargs))
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            return asyncio.ensure_future(coroutine(*args, **kwargs))
+        else:
+            return loop.run_until_complete(coroutine(*args, **kwargs))
+    except RuntimeError:
+        ...

--- a/eolic/helpers/coroutines.py
+++ b/eolic/helpers/coroutines.py
@@ -1,0 +1,21 @@
+"""Module for coroutine helpers."""
+
+import asyncio
+from typing import Any, Callable
+
+
+def run_coroutine(coroutine: Callable[..., Any], *args, **kwargs) -> Any:
+    """
+    Run a coroutine in the appropriate context.
+
+    Args:
+        coroutine (Awaitable[Any]): The coroutine to run.
+
+    Returns:
+        Any: The result of the coroutine.
+    """
+    loop = asyncio.get_event_loop()
+    if loop.is_running():
+        return asyncio.ensure_future(coroutine(*args, **kwargs))
+    else:
+        return loop.run_until_complete(coroutine(*args, **kwargs))

--- a/eolic/remote.py
+++ b/eolic/remote.py
@@ -15,6 +15,8 @@ from typing import Any, Dict, List
 
 import requests
 
+from .helpers.coroutines import run_coroutine
+
 from .model import (
     EventDTO,
     EventRemoteTarget,
@@ -88,11 +90,7 @@ class EventRemoteTargetHandler:
             *args: Variable length argument list for the event.
             **kwargs: Arbitrary keyword arguments for the event.
         """
-        loop = asyncio.get_event_loop()
-        if loop.is_running():
-            loop.run_in_executor(None, self._emit_async, event, *args, **kwargs)
-        else:
-            loop.run_until_complete(self._emit_async(event, *args, **kwargs))
+        run_coroutine(self._emit_async, event, *args, **kwargs)
 
     async def _emit_async(self, event: Any, *args, **kwargs) -> None:
         """
@@ -116,11 +114,7 @@ class EventRemoteTargetHandler:
 
     def wait_for_all(self) -> None:
         """Wait for all asynchronous tasks to complete."""
-        loop = asyncio.get_event_loop()
-        if loop.is_running():
-            loop.run_in_executor(None, self._wait_for_all_async)
-        else:
-            loop.run_until_complete(self._wait_for_all_async())
+        run_coroutine(self._wait_for_all_async)
 
     async def _wait_for_all_async(self) -> None:
         """Asynchronously wait for all tasks to complete."""

--- a/eolic/remote.py
+++ b/eolic/remote.py
@@ -102,9 +102,10 @@ class EventRemoteTargetHandler:
             **kwargs: Arbitrary keyword arguments for the event.
         """
         tasks = []
+        dispatcher_factory = EventRemoteDispatcherFactory()
         for target in self.targets:
             if target.events is None or event in target.events:
-                dispatcher = EventRemoteDispatcherFactory().create(target)
+                dispatcher = dispatcher_factory.create(target)
                 task: asyncio.Task = asyncio.create_task(
                     dispatcher.dispatch(event, *args, **kwargs)
                 )

--- a/eolic/remote.py
+++ b/eolic/remote.py
@@ -111,7 +111,7 @@ class EventRemoteTargetHandler:
                 )
                 tasks.append(task)
 
-        await asyncio.gather(*tasks)
+        await asyncio.gather(*tasks, return_exceptions=True)
 
     def wait_for_all(self) -> None:
         """Wait for all asynchronous tasks to complete."""
@@ -119,7 +119,7 @@ class EventRemoteTargetHandler:
 
     async def _wait_for_all_async(self) -> None:
         """Asynchronously wait for all tasks to complete."""
-        await asyncio.gather(*self.tasks)
+        await asyncio.gather(*self.tasks, return_exceptions=True)
         self.tasks.clear()
 
 

--- a/eolic/task_manager.py
+++ b/eolic/task_manager.py
@@ -1,0 +1,29 @@
+"""Module for handling taslk in Eolic."""
+
+import asyncio
+from typing import Any, Callable
+from eolic.helpers.coroutines import run_coroutine
+
+
+class TaskManager:
+    """Handles the creation and management of asynchronous tasks."""
+
+    def create_task(self, func: Callable[..., Any], *args, **kwargs) -> None:
+        """Create a new asynchronous task."""
+
+        async def _async_func():
+            if not asyncio.iscoroutinefunction(func):
+                func(*args, **kwargs)
+            else:
+                await func(*args, **kwargs)
+
+        asyncio.create_task(_async_func())
+
+    def wait_for_all(self) -> None:
+        """Wait for all asynchronous tasks to complete."""
+        run_coroutine(self._wait_for_all_async)
+
+    async def _wait_for_all_async(self) -> None:
+        """Asynchronously wait for all tasks to complete."""
+        pending = asyncio.all_tasks() - {asyncio.current_task()}
+        await asyncio.gather(*pending)

--- a/eolic/task_manager.py
+++ b/eolic/task_manager.py
@@ -1,12 +1,32 @@
-"""Module for handling taslk in Eolic."""
+"""Module for handling tasks in Eolic."""
 
 import asyncio
+import atexit
+import signal
 from typing import Any, Callable
 from eolic.helpers.coroutines import run_coroutine
 
 
 class TaskManager:
     """Handles the creation and management of asynchronous tasks."""
+
+    def __init__(self) -> None:
+        """Initialize the TaskManager."""
+        self._register_cleanup()
+
+    def _register_cleanup(self) -> None:
+        """Register cleanup functions for the task manager to run before exiting the application."""
+        atexit.register(self._cleanup)
+        signal.signal(signal.SIGINT, self._handle_signal)
+        signal.signal(signal.SIGTERM, self._handle_signal)
+
+    def _cleanup(self):
+        """Clean up the task manager."""
+        self.wait_for_all()
+
+    def _handle_signal(self, *_) -> None:
+        """Handle termination signals."""
+        self._cleanup()
 
     def create_task(self, func: Callable[..., Any], *args, **kwargs) -> None:
         """Create a new asynchronous task."""

--- a/examples/integrations/fastapi_plugin/notification_service.py
+++ b/examples/integrations/fastapi_plugin/notification_service.py
@@ -9,7 +9,7 @@ eolic = Eolic()
 
 
 @eolic.on("user_created")
-def handle_user_created(id: int, name: str, email: str):
+async def handle_user_created(id: int, name: str, email: str):
     """Handle the user created event."""
     # Handle the user created event (e.g., send a notification)
     print(f"Notification: User {name} with email {email} was created!")

--- a/examples/integrations/fastapi_plugin/user_service.py
+++ b/examples/integrations/fastapi_plugin/user_service.py
@@ -10,7 +10,7 @@ app = FastAPI()
 eolic = Eolic(
     remote_targets=[
         "http://127.0.0.1:8001/user-events",
-        "https://webhook.site/02479cf4-12e7-4d68-a900-c3f9e1daba56",
+        "https://a/event",
     ]
 )
 

--- a/examples/integrations/fastapi_plugin/user_service.py
+++ b/examples/integrations/fastapi_plugin/user_service.py
@@ -10,7 +10,6 @@ app = FastAPI()
 eolic = Eolic(
     remote_targets=[
         "http://127.0.0.1:8001/user-events",
-        "https://a/event",
     ]
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,15 @@ pre-commit = "^3.7.1"
 pydocstyle = "^6.3.0"
 flake8-pyproject = "^1.2.3"
 commitizen = "^3.28.0"
-pytest-asyncio = "^0.23.8"
+httpx = "^0.27.0"
+
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.2.2"
 pytest-mock = "^3.14.0"
 pytest-cov = "^5.0.0"
 pytest-order = "^1.2.1"
+pytest-asyncio = "^0.23.8"
 
 [tool.commitizen]
 name = "cz_conventional_commits"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pre-commit = "^3.7.1"
 pydocstyle = "^6.3.0"
 flake8-pyproject = "^1.2.3"
 commitizen = "^3.28.0"
+pytest-asyncio = "^0.23.8"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.2.2"
@@ -60,3 +61,6 @@ match = '((?!.run).)*\.py'
 
 [tool.bandit]
 exclude_dirs = ["tests/"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -65,7 +65,7 @@ def test_create_url_dispatcher(
 # Dispatching Events
 
 
-def test_dispatch_event_to_url(
+async def test_dispatch_event_to_url(
     mocker: MockFixture, url_target: EventRemoteURLTarget
 ) -> None:
     """
@@ -76,8 +76,10 @@ def test_dispatch_event_to_url(
         url_target (EventRemoteURLTarget): An instance of EventRemoteURLTarget.
     """
     dispatcher = EventRemoteURLDispatcher(url_target)
+
     mock_post = mocker.patch("requests.post")
-    dispatcher.dispatch(GameEvents.ON_PLAYER_JOIN, "Archer")
+    await dispatcher.dispatch(GameEvents.ON_PLAYER_JOIN, "Archer")
+
     mock_post.assert_called_once_with(
         "https://webhook.site/test-url",
         json={
@@ -90,7 +92,7 @@ def test_dispatch_event_to_url(
     )
 
 
-def test_dispatch_event_to_url_with_different_event(
+async def test_dispatch_event_to_url_with_different_event(
     mocker: MockFixture, url_target: EventRemoteURLTarget
 ) -> None:
     """
@@ -101,8 +103,10 @@ def test_dispatch_event_to_url_with_different_event(
         url_target (EventRemoteURLTarget): An instance of EventRemoteURLTarget.
     """
     dispatcher = EventRemoteURLDispatcher(url_target)
+
     mock_post = mocker.patch("requests.post")
-    dispatcher.dispatch(GameEvents.ON_PLAYER_ATTACK, "Archer", "Goblin", 30)
+    await dispatcher.dispatch(GameEvents.ON_PLAYER_ATTACK, "Archer", "Goblin", 30)
+
     mock_post.assert_called_once_with(
         "https://webhook.site/test-url",
         json={
@@ -115,7 +119,7 @@ def test_dispatch_event_to_url_with_different_event(
     )
 
 
-def test_dispatcher_error_handling(
+async def test_dispatcher_error_handling(
     mocker: MockFixture, url_target: EventRemoteURLTarget
 ) -> None:
     """
@@ -126,9 +130,11 @@ def test_dispatcher_error_handling(
         url_target (EventRemoteURLTarget): An instance of EventRemoteURLTarget.
     """
     dispatcher = EventRemoteURLDispatcher(url_target)
+
     mock_post = mocker.patch("requests.post", side_effect=Exception("Request failed"))
     with pytest.raises(Exception, match="Request failed"):
-        dispatcher.dispatch(GameEvents.ON_PLAYER_JOIN, "Archer")
+        await dispatcher.dispatch(GameEvents.ON_PLAYER_JOIN, "Archer")
+
     mock_post.assert_called_once_with(
         "https://webhook.site/test-url",
         json={

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -27,7 +27,7 @@ def url_target() -> EventRemoteURLTarget:
     """
     return EventRemoteURLTarget(
         type="url",
-        address="https://webhook.site/test-url",
+        address="https://a/test-url",
         headers={"X-Api-Key": "test"},
         timeout=10,
     )
@@ -81,7 +81,7 @@ async def test_dispatch_event_to_url(
     await dispatcher.dispatch(GameEvents.ON_PLAYER_JOIN, "Archer")
 
     mock_post.assert_called_once_with(
-        "https://webhook.site/test-url",
+        "https://a/test-url",
         json={
             "event": GameEvents.ON_PLAYER_JOIN.value,
             "args": ("Archer",),
@@ -108,7 +108,7 @@ async def test_dispatch_event_to_url_with_different_event(
     await dispatcher.dispatch(GameEvents.ON_PLAYER_ATTACK, "Archer", "Goblin", 30)
 
     mock_post.assert_called_once_with(
-        "https://webhook.site/test-url",
+        "https://a/test-url",
         json={
             "event": GameEvents.ON_PLAYER_ATTACK.value,
             "args": ("Archer", "Goblin", 30),
@@ -136,7 +136,7 @@ async def test_dispatcher_error_handling(
         await dispatcher.dispatch(GameEvents.ON_PLAYER_JOIN, "Archer")
 
     mock_post.assert_called_once_with(
-        "https://webhook.site/test-url",
+        "https://a/test-url",
         json={
             "event": GameEvents.ON_PLAYER_JOIN.value,
             "args": ("Archer",),

--- a/tests/test_eolic.py
+++ b/tests/test_eolic.py
@@ -7,7 +7,6 @@ emitting events, and handling remote targets.
 
 from unittest.mock import patch
 from tests.common import GameEvents
-from pydantic import ValidationError
 from pytest_mock import MockFixture
 import pytest
 from eolic import Eolic
@@ -36,8 +35,35 @@ def eolic_instance() -> Eolic:
     )
 
 
-# Initialization
-@pytest.mark.order(1)
+@pytest.fixture(autouse=True)
+def clear_instance(eolic_instance: Eolic) -> None:
+    """
+    Fixture to clear targets before each test.
+
+    Args:
+        target_handler (EventRemoteTargetHandler): An instance of EventRemoteTargetHandler.
+    """
+    eolic_instance.listener_handler.clear()
+    eolic_instance.remote_target_handler.clear()
+
+
+def test_instance_with_remote_targets() -> None:
+    Eolic._instances.clear()
+    eolic = Eolic(
+        remote_targets=[
+            {
+                "type": "url",
+                "address": "https://a/test-url",
+                "headers": {"X-Api-Key": "test"},
+                "events": [GameEvents.ON_PLAYER_JOIN],
+            }
+        ]
+    )
+
+    assert len(eolic.remote_target_handler.targets) == 1
+    assert eolic.remote_target_handler.targets[0].address == "https://a/test-url"
+
+
 def test_initialization(eolic_instance: Eolic) -> None:
     """
     Test initialization of Eolic.
@@ -49,54 +75,11 @@ def test_initialization(eolic_instance: Eolic) -> None:
     assert isinstance(eolic_instance.listener_handler, EventListenerHandler)
 
 
-# Registering Targets
-@pytest.mark.order(2)
-def test_register_single_target(eolic_instance: Eolic) -> None:
-    """
-    Test registering a single remote target.
-
-    Args:
-        eolic_instance (Eolic): An instance of Eolic.
-    """
-    target = {
-        "type": "url",
-        "address": "https://a/another-url",
-        "headers": {"X-Api-Key": "another"},
-        "events": [GameEvents.ON_MONSTER_DEFEATED],
-    }
-    eolic_instance.register_target(target)
-    assert len(eolic_instance.remote_target_handler.targets) == 2
+def test_register_listener(eolic_instance: Eolic) -> None:
+    eolic_instance.register_listener(GameEvents.ON_PLAYER_JOIN, lambda: None)
+    assert len(eolic_instance.listener_handler.listeners) == 1
 
 
-@pytest.mark.order(3)
-def test_register_multiple_targets(eolic_instance: Eolic) -> None:
-    """
-    Test registering multiple remote targets.
-
-    Args:
-        eolic_instance (Eolic): An instance of Eolic.
-    """
-    targets = [
-        {
-            "type": "url",
-            "address": "https://a/target1",
-            "headers": {"X-Api-Key": "key1"},
-        },
-        {
-            "type": "url",
-            "address": "https://a/target2",
-            "headers": {"X-Api-Key": "key2"},
-        },
-    ]
-    for target in targets:
-        eolic_instance.register_target(target)
-
-    assert len(eolic_instance.remote_target_handler.targets) == 4
-
-    eolic_instance.remote_target_handler.clear()
-
-
-@pytest.mark.order(4)
 def test_register_invalid_target(eolic_instance: Eolic) -> None:
     """
     Test handling of invalid remote target registration.
@@ -108,61 +91,6 @@ def test_register_invalid_target(eolic_instance: Eolic) -> None:
         eolic_instance.register_target(123)  # Invalid type
 
 
-# Registering Listeners
-@pytest.mark.order(5)
-def test_register_single_listener(eolic_instance: Eolic) -> None:
-    """
-    Test registering a single event listener.
-
-    Args:
-        eolic_instance (Eolic): An instance of Eolic.
-    """
-
-    def dummy_listener(*args, **kwargs):
-        pass
-
-    eolic_instance.register_listener(GameEvents.ON_PLAYER_JOIN, dummy_listener)
-    listeners = eolic_instance.listener_handler._listener_map[GameEvents.ON_PLAYER_JOIN]
-    assert dummy_listener in listeners
-
-
-@pytest.mark.order(6)
-def test_register_multiple_listeners(eolic_instance: Eolic) -> None:
-    """
-    Test registering multiple event listeners for the same event.
-
-    Args:
-        eolic_instance (Eolic): An instance of Eolic.
-    """
-
-    def listener1(*args, **kwargs):
-        pass
-
-    def listener2(*args, **kwargs):
-        pass
-
-    eolic_instance.register_listener(GameEvents.ON_PLAYER_JOIN, listener1)
-    eolic_instance.register_listener(GameEvents.ON_PLAYER_JOIN, listener2)
-    listeners = eolic_instance.listener_handler._listener_map[GameEvents.ON_PLAYER_JOIN]
-    assert listener1 in listeners and listener2 in listeners
-
-
-@pytest.mark.order(7)
-def test_register_invalid_listener(eolic_instance: Eolic) -> None:
-    """
-    Test handling of invalid event listener registration.
-
-    Args:
-        eolic_instance (Eolic): An instance of Eolic.
-    """
-    with pytest.raises(ValidationError):
-        eolic_instance.register_listener(
-            GameEvents.ON_PLAYER_JOIN, "not a function"
-        )  # Invalid listener
-
-
-# Event Emission
-@pytest.mark.order(8)
 def test_emit_event_to_single_listener(eolic_instance: Eolic) -> None:
     """
     Test emitting an event to a single listener.
@@ -180,7 +108,28 @@ def test_emit_event_to_single_listener(eolic_instance: Eolic) -> None:
     assert "Archer" in results
 
 
-@pytest.mark.order(9)
+def test_emit_event_to_async_listeners(eolic_instance: Eolic) -> None:
+    """
+    Test emitting an event to multiple listeners.
+
+    Args:
+        eolic_instance (Eolic): An instance of Eolic.
+    """
+    results1 = []
+    results2 = []
+
+    @eolic_instance.on(GameEvents.ON_PLAYER_JOIN)
+    async def listener1(player_name):
+        results1.append(player_name)
+
+    @eolic_instance.on(GameEvents.ON_PLAYER_JOIN)
+    async def listener2(player_name):
+        results2.append(player_name)
+
+    eolic_instance.emit(GameEvents.ON_PLAYER_JOIN, "Archer")
+    assert "Archer" in results1 and "Archer" in results2
+
+
 def test_emit_event_to_multiple_listeners(eolic_instance: Eolic) -> None:
     """
     Test emitting an event to multiple listeners.
@@ -203,7 +152,6 @@ def test_emit_event_to_multiple_listeners(eolic_instance: Eolic) -> None:
     assert "Archer" in results1 and "Archer" in results2
 
 
-@pytest.mark.order(10)
 def test_emit_event_with_arguments(eolic_instance: Eolic) -> None:
     """
     Test emitting an event with arguments to a listener.
@@ -221,8 +169,6 @@ def test_emit_event_with_arguments(eolic_instance: Eolic) -> None:
     assert ("Archer", "Goblin", 30) in results
 
 
-# Decorator Functionality
-@pytest.mark.order(11)
 def test_decorator_functionality(eolic_instance: Eolic) -> None:
     """
     Test the functionality of the decorator for registering listeners.
@@ -240,7 +186,6 @@ def test_decorator_functionality(eolic_instance: Eolic) -> None:
     assert "Archer" in results
 
 
-@pytest.mark.order(12)
 def test_decorator_preserves_function_properties(eolic_instance: Eolic) -> None:
     """
     Test that the decorator preserves the original function properties.
@@ -258,8 +203,6 @@ def test_decorator_preserves_function_properties(eolic_instance: Eolic) -> None:
     assert handle_player_join.__doc__ == "Create dummy callback for testing."
 
 
-# Remote Target Handling
-@pytest.mark.order(13)
 def test_remote_target_receives_event(
     eolic_instance: Eolic, mocker: MockFixture
 ) -> None:

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -35,7 +35,6 @@ def clear_targets(listener_handler: EventListenerHandler) -> None:
 # Registering Listeners
 
 
-@pytest.mark.order(23)
 def test_register_single_listener(listener_handler: EventListenerHandler) -> None:
     """
     Test registering a single event listener.
@@ -53,7 +52,6 @@ def test_register_single_listener(listener_handler: EventListenerHandler) -> Non
     assert dummy_listener in listeners
 
 
-@pytest.mark.order(24)
 def test_register_multiple_listeners(listener_handler: EventListenerHandler) -> None:
     """
     Test registering multiple event listeners for the same event.
@@ -76,7 +74,23 @@ def test_register_multiple_listeners(listener_handler: EventListenerHandler) -> 
     assert listener2 in listeners
 
 
-@pytest.mark.order(25)
+def test_register_async_listeners(listener_handler: EventListenerHandler) -> None:
+    """
+    Test registering async event listeners for the same event.
+
+    Args:
+        listener_handler (EventListenerHandler): An instance of EventListenerHandler.
+    """
+
+    async def listener(*args, **kwargs):
+        pass
+
+    listener_handler.register(GameEvents.ON_PLAYER_JOIN, listener)
+
+    listeners = listener_handler._listener_map[GameEvents.ON_PLAYER_JOIN]
+    assert len(listeners) == 1
+
+
 def test_register_listeners_for_different_events(
     listener_handler: EventListenerHandler,
 ) -> None:
@@ -106,7 +120,6 @@ def test_register_listeners_for_different_events(
 # Event Listener Map
 
 
-@pytest.mark.order(26)
 def test_listener_map_structure(listener_handler: EventListenerHandler) -> None:
     """
     Test the structure of the listener map.
@@ -129,7 +142,6 @@ def test_listener_map_structure(listener_handler: EventListenerHandler) -> None:
 # Listener Execution
 
 
-@pytest.mark.order(27)
 def test_listener_execution(listener_handler: EventListenerHandler) -> None:
     """
     Test the execution of a registered listener.
@@ -149,7 +161,6 @@ def test_listener_execution(listener_handler: EventListenerHandler) -> None:
     assert "executed" in results
 
 
-@pytest.mark.order(28)
 def test_listener_execution_with_arguments(
     listener_handler: EventListenerHandler,
 ) -> None:

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -37,7 +37,6 @@ def clear_targets(target_handler: EventRemoteTargetHandler) -> None:
 # Parsing Targets
 
 
-@pytest.mark.order(14)
 def test_parse_string_target(target_handler: EventRemoteTargetHandler) -> None:
     """
     Test parsing a string target.
@@ -51,7 +50,6 @@ def test_parse_string_target(target_handler: EventRemoteTargetHandler) -> None:
     assert parsed_target.address == "https://a/test-url"
 
 
-@pytest.mark.order(15)
 def test_parse_dict_target(target_handler: EventRemoteTargetHandler) -> None:
     """
     Test parsing a dictionary target.
@@ -70,7 +68,6 @@ def test_parse_dict_target(target_handler: EventRemoteTargetHandler) -> None:
     assert parsed_target.headers["X-Api-Key"] == "test"
 
 
-@pytest.mark.order(16)
 def test_parse_invalid_target(target_handler: EventRemoteTargetHandler) -> None:
     """
     Test handling of invalid target formats.
@@ -85,7 +82,6 @@ def test_parse_invalid_target(target_handler: EventRemoteTargetHandler) -> None:
 # Registering Targets
 
 
-@pytest.mark.order(17)
 def test_register_single_target(target_handler: EventRemoteTargetHandler) -> None:
     """
     Test registering a single target.
@@ -98,7 +94,6 @@ def test_register_single_target(target_handler: EventRemoteTargetHandler) -> Non
     assert len(target_handler.targets) == 1
 
 
-@pytest.mark.order(18)
 def test_register_multiple_targets(target_handler: EventRemoteTargetHandler) -> None:
     """
     Test registering multiple targets.
@@ -119,7 +114,6 @@ def test_register_multiple_targets(target_handler: EventRemoteTargetHandler) -> 
     assert len(target_handler.targets) == 2
 
 
-@pytest.mark.order(19)
 def test_register_duplicate_targets(target_handler: EventRemoteTargetHandler) -> None:
     """
     Test handling of duplicate target registrations.
@@ -138,7 +132,6 @@ def test_register_duplicate_targets(target_handler: EventRemoteTargetHandler) ->
 # Emitting Events
 
 
-@pytest.mark.order(20)
 def test_emit_event_to_single_target(target_handler: EventRemoteTargetHandler) -> None:
     """
     Test emitting an event to a single target.
@@ -167,7 +160,6 @@ def test_emit_event_to_single_target(target_handler: EventRemoteTargetHandler) -
         )
 
 
-@pytest.mark.order(21)
 def test_emit_event_to_multiple_targets(
     target_handler: EventRemoteTargetHandler,
 ) -> None:
@@ -197,7 +189,6 @@ def test_emit_event_to_multiple_targets(
         assert mock_post.call_count == 2
 
 
-@pytest.mark.order(22)
 def test_filter_targets_by_event(target_handler: EventRemoteTargetHandler) -> None:
     """
     Test filtering targets by specific events.

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -45,10 +45,10 @@ def test_parse_string_target(target_handler: EventRemoteTargetHandler) -> None:
     Args:
         target_handler (EventRemoteTargetHandler): An instance of EventRemoteTargetHandler.
     """
-    target = "https://webhook.site/test-url"
+    target = "https://a/test-url"
     parsed_target = target_handler._parse_target(target)
     assert isinstance(parsed_target, EventRemoteURLTarget)
-    assert parsed_target.address == "https://webhook.site/test-url"
+    assert parsed_target.address == "https://a/test-url"
 
 
 @pytest.mark.order(15)
@@ -61,12 +61,12 @@ def test_parse_dict_target(target_handler: EventRemoteTargetHandler) -> None:
     """
     target = {
         "type": "url",
-        "address": "https://webhook.site/test-url",
+        "address": "https://a/test-url",
         "headers": {"X-Api-Key": "test"},
     }
     parsed_target = target_handler._parse_target(target)
     assert isinstance(parsed_target, EventRemoteURLTarget)
-    assert parsed_target.address == "https://webhook.site/test-url"
+    assert parsed_target.address == "https://a/test-url"
     assert parsed_target.headers["X-Api-Key"] == "test"
 
 
@@ -93,7 +93,7 @@ def test_register_single_target(target_handler: EventRemoteTargetHandler) -> Non
     Args:
         target_handler (EventRemoteTargetHandler): An instance of EventRemoteTargetHandler.
     """
-    target = "https://webhook.site/test-url"
+    target = "https://a/test-url"
     target_handler.register(target)
     assert len(target_handler.targets) == 1
 
@@ -107,10 +107,10 @@ def test_register_multiple_targets(target_handler: EventRemoteTargetHandler) -> 
         target_handler (EventRemoteTargetHandler): An instance of EventRemoteTargetHandler.
     """
     targets = [
-        "https://webhook.site/target1",
+        "https://a/target1",
         {
             "type": "url",
-            "address": "https://webhook.site/target2",
+            "address": "https://a/target2",
             "headers": {"X-Api-Key": "key2"},
         },
     ]
@@ -127,7 +127,7 @@ def test_register_duplicate_targets(target_handler: EventRemoteTargetHandler) ->
     Args:
         target_handler (EventRemoteTargetHandler): An instance of EventRemoteTargetHandler.
     """
-    target = "https://webhook.site/test-url"
+    target = "https://a/test-url"
     target_handler.register(target)
     target_handler.register(target)
     assert (
@@ -149,14 +149,14 @@ def test_emit_event_to_single_target(target_handler: EventRemoteTargetHandler) -
     with patch("requests.post") as mock_post:
         target = {
             "type": "url",
-            "address": "https://webhook.site/test-url",
+            "address": "https://a/test-url",
             "headers": {"X-Api-Key": "test"},
         }
         target_handler.register(target)
         target_handler.emit(GameEvents.ON_PLAYER_JOIN, "Archer")
         target_handler.wait_for_all()
         mock_post.assert_called_once_with(
-            "https://webhook.site/test-url",
+            "https://a/test-url",
             json={
                 "event": GameEvents.ON_PLAYER_JOIN.value,
                 "args": ("Archer",),
@@ -181,12 +181,12 @@ def test_emit_event_to_multiple_targets(
         targets = [
             {
                 "type": "url",
-                "address": "https://webhook.site/target1",
+                "address": "https://a/target1",
                 "headers": {"X-Api-Key": "key1"},
             },
             {
                 "type": "url",
-                "address": "https://webhook.site/target2",
+                "address": "https://a/target2",
                 "headers": {"X-Api-Key": "key2"},
             },
         ]
@@ -206,26 +206,29 @@ def test_filter_targets_by_event(target_handler: EventRemoteTargetHandler) -> No
         target_handler (EventRemoteTargetHandler): An instance of EventRemoteTargetHandler.
     """
     with patch("requests.post") as mock_post:
+        mock_post.return_value.status_code = 200
         targets = [
             {
                 "type": "url",
-                "address": "https://webhook.site/target1",
+                "address": "https://a/target1",
                 "headers": {"X-Api-Key": "key1"},
                 "events": [GameEvents.ON_PLAYER_JOIN],
             },
             {
                 "type": "url",
-                "address": "https://webhook.site/target2",
+                "address": "https://a/target2",
                 "headers": {"X-Api-Key": "key2"},
                 "events": [GameEvents.ON_MONSTER_DEFEATED],
             },
         ]
         for target in targets:
             target_handler.register(target)
+
         target_handler.emit(GameEvents.ON_PLAYER_JOIN, "Archer")
         target_handler.wait_for_all()
+
         mock_post.assert_called_once_with(
-            "https://webhook.site/target1",
+            "https://a/target1",
             json={
                 "event": GameEvents.ON_PLAYER_JOIN.value,
                 "args": ("Archer",),


### PR DESCRIPTION
### Description
In this change eolic will support async listeners, and also changes how remote listeners are called.
In the previous version eolic was using ThreadPoolWorker to dispatch all events, now it will use the asyncio to handle it.

### What kind of change does this PR introduce?

- [X] Feature
- [X] Refactoring (no functional changes, no api changes)
- [X] Tests

### How Has This Been Tested?

The code of fastapi was slightly change locally fastapi example to use async handlers:

- Registering and emitting events for these listeners
- Raising exception on event handler method

**Unit tests added:**
- test_listener.py -> test_register_async_listeners()
- test_eolic.py -> test_emit_event_to_async_listeners()

### Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
